### PR TITLE
Update .gitignore to ignore vi backup files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .DS_Store
 thunbs.db
 
+# vi/vim/gvim backup files
+*~


### PR DESCRIPTION
Handles ~ files left by vi/vim/gvim.

Closes issue #75 
